### PR TITLE
[bug] log to syslog

### DIFF
--- a/pkg/leap_mx.init
+++ b/pkg/leap_mx.init
@@ -16,8 +16,6 @@ FILE=/usr/share/app/leap_mx.tac
 LOGFILE=/var/log/leap_mx.log
 TWISTD_PATH=/usr/bin/twistd
 
-[ -r /etc/default/leap_mx ] && . /etc/default/leap_mx
-
 . /lib/lsb/init-functions
 
 test -r $file || exit 0
@@ -32,7 +30,6 @@ case "$1" in
                           --pidfile=$PIDFILE \
                           --rundir=$RUNDIR \
                           --python=$FILE \
-                          --logfile=$LOGFILE \
                           --syslog --prefix=leap-mx
         echo "."
     ;;


### PR DESCRIPTION
In a conversation about logging, platform developers found that best practice
would be to have all platform pieces loggin to syslog, because then we
automatically gain some useful functionalities as rotation, ip anonymization,
and others.

Before this commit, we were passing 2 conflicting logging options to twistd
when initializing the service in the initscript: logging to a file and logging
to syslog. The latter option was overriding the former. Also, we were using a
log file configuration from an /etc/default/leap_mx file. This commit alters
the initscript so we only pass a syslog logging option and also removes the
importing of the /etc/default/leap_mx file