### PR TITLE
[bug] remove --syslog twistd option

### DIFF
--- a/changes/bug_6937_remove-syslog-option
+++ b/changes/bug_6937_remove-syslog-option
@@ -1,0 +1,2 @@
+  o Remove logging to syslog for now. We should only do this in the future,
+    when the platform is ready for it. Closes #6937.

--- a/pkg/leap-mx.init
+++ b/pkg/leap-mx.init
@@ -33,7 +33,7 @@ case "$1" in
                           --rundir=$RUNDIR \
                           --python=$FILE \
                           --logfile=$LOGFILE \
-                          --syslog --prefix=leap-mx
+                          --prefix=leap-mx
         echo "."
     ;;
 


### PR DESCRIPTION
We currently manage log messages with the python's standard library logging
module. In order to change that behaviour and let twistd manage log messages
and send them to syslog, some customization has to be made. For now, we just
remove the syslog option from the initscript.