### PR TITLE
[pkg] separate leap requirements

### DIFF
--- a/pkg/requirements-leap.pip
+++ b/pkg/requirements-leap.pip
@@ -1,0 +1,3 @@
+leap.common>=0.3.5
+leap.soledad.common>=0.4.5
+leap.keymanager>=0.3.4

--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -7,7 +7,3 @@ paisley>=0.3.1
 # in soledad-common, but we need to declare here
 # for the time being.
 couchdb
-
-leap.common>=0.3.5
-leap.soledad.common>=0.4.5
-leap.keymanager>=0.3.4

--- a/pkg/utils/reqs.py
+++ b/pkg/utils/reqs.py
@@ -22,6 +22,22 @@ import re
 import sys
 
 
+def is_develop_mode():
+    """
+    Returns True if we're calling the setup script using the argument for
+    setuptools development mode.
+
+    This avoids messing up with dependency pinning and order, the
+    responsibility of installing the leap dependencies is left to the
+    developer.
+    """
+    args = sys.argv
+    devflags = "setup.py", "develop"
+    if (args[0], args[1]) == devflags:
+        return True
+    return False
+
+
 def get_reqs_from_files(reqfiles):
     """
     Returns the contents of the top requirement file listed as a

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ versioneer.versionfile_build = 'leap/mx/_version.py'
 versioneer.tag_prefix = ''  # tags are like 1.2.0
 versioneer.parentdir_prefix = 'leap.mx-'
 
-from pkg.utils.reqs import parse_requirements
+from pkg.utils.reqs import parse_requirements, is_develop_mode
 
 trove_classifiers = [
     'Development Status :: 3 - Alpha',
@@ -114,6 +114,24 @@ else:
     # placed by distutils, using whatever interpreter is
     # available.
     data_files = [("/usr/local/bin/", ["pkg/mx.tac"])]
+
+
+requirements = parse_requirements()
+
+if is_develop_mode():
+    print
+    print ("[WARNING] Skipping leap-specific dependencies "
+           "because development mode is detected.")
+    print ("[WARNING] You can install "
+           "the latest published versions with "
+           "'pip install -r pkg/requirements-leap.pip'")
+    print ("[WARNING] Or you can instead do 'python setup.py develop' "
+           "from the parent folder of each one of them.")
+    print
+else:
+    requirements += parse_requirements(
+        reqfiles=["pkg/requirements-leap.pip"])
+
 setup(
     name='leap.mx',
     version=VERSION,
@@ -134,8 +152,8 @@ setup(
     namespace_packages=["leap"],
     package_dir={'': 'src'},
     packages=find_packages('src'),
-    #test_suite='leap.mx.tests',
-    install_requires=parse_requirements(),
+    # test_suite='leap.mx.tests',
+    install_requires=requirements,
     classifiers=trove_classifiers,
     data_files=data_files
 )


### PR DESCRIPTION
this is part of a process to make the setup of the development mode less
troublesome. from now on, setting up a virtualenv in pure development
mode will be as easy as telling pip to just install the external
dependencies::

  pip install -r pkg/requirements.pip

and traversing all the leap repos for the needed leap dependencies doing::

  python setup.py develop

- Related: #7288