### PR TITLE
[feat] use wheels to install dependencies

### DIFF
--- a/pkg/generate_wheels.sh
+++ b/pkg/generate_wheels.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Generate wheels for dependencies
+
+if [ "$WHEELHOUSE" = "" ]; then
+    WHEELHOUSE=$HOME/wheelhouse
+fi
+
+pip wheel --wheel-dir $WHEELHOUSE pip
+pip wheel --wheel-dir $WHEELHOUSE -r pkg/requirements.pip
+if [ -f pkg/requirements-testing.pip ]; then
+    pip wheel --wheel-dir $WHEELHOUSE -r pkg/requirements-testing.pip
+fi

--- a/pkg/pip_install_requirements.sh
+++ b/pkg/pip_install_requirements.sh
@@ -1,4 +1,69 @@
 #!/bin/sh
-# Update pip and install LEAP base requirements.
-pip install -U pip
-pip install -r pkg/requirements.pip
+# Update pip and install LEAP base/testing requirements.
+# For convenience, $insecure_packages are allowed with insecure flags enabled.
+# Use at your own risk.
+# See $usage for help
+
+insecure_packages=""
+
+return_wheelhouse() {
+    if [ "$WHEELHOUSE" = "" ]; then
+	WHEELHOUSE=$HOME/wheelhouse
+    fi
+
+    if [ ! -d "$WHEELHOUSE" ]; then
+	mkdir $WHEELHOUSE
+    fi
+
+    echo "$WHEELHOUSE"
+}
+
+show_help() {
+    usage="Usage: $0 [--testing]\n --testing\tInstall dependencies from requirements-testing.pip\n
+\t\tOtherwise, it will install requirements.pip"
+    echo $usage
+
+    exit 1
+}
+
+process_arguments() {
+    testing=false
+    while [ "$#" -gt 0 ]; do
+	# From http://stackoverflow.com/a/31443098
+	case "$1" in
+	    --help) show_help;;
+	    --testing) testing=true; shift 1;;
+
+	    -h) show_help;;
+	    -*) echo "unknown option: $1" >&2; exit 1;;
+	esac
+    done
+}
+
+return_insecure_flags() {
+    for insecure_package in $insecure_packages; do
+	flags="$flags --allow-external $insecure_package --allow-unverified $insecure_package"
+    done
+
+    echo $flags
+}
+
+return_packages() {
+    if $testing ; then
+	packages="-r pkg/requirements-testing.pip"
+    else
+	packages="-r pkg/requirements.pip"
+    fi
+
+    echo $packages
+}
+
+process_arguments $@
+wheelhouse=`return_wheelhouse`
+install_options="-U --find-links=$wheelhouse"
+insecure_flags=`return_insecure_flags`
+packages=`return_packages`
+
+pip install -U wheel
+pip install $install_options pip
+pip install $install_options $insecure_flags $packages


### PR DESCRIPTION
generate_wheels uses $WHEELHOUSE to generate and store the wheels for
requirements.pip and requirements-testing.pip (if it exists).

pip_install_requirements.sh installs requirements.pip from them if
possible (if not, then it fetches them from pypi) or, if passed the
--testing flag, it installs requirements-testing.pip.

- Related: 7327