### PR TITLE
[pkg] bump soledad-common dependency

### DIFF
--- a/pkg/requirements-leap.pip
+++ b/pkg/requirements-leap.pip
@@ -1,3 +1,3 @@
 leap.common>=0.3.5
-leap.soledad.common>=0.4.5
+leap.soledad.common>=0.8.0
 leap.keymanager>=0.3.4


### PR DESCRIPTION
needed because the ServerDocument refactor

- Releases: 0.8.0