### PR TITLE
add systemd service file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: drebs <drebs@leap.se>
 Uploader: Micah Anderson <micah@debian.org>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.6.6-3), debhelper (>= 9)
+Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.6.6-3), debhelper (>= 9), dh-systemd
 Standards-Version: 3.9.6
 
 Package: leap-mx

--- a/debian/leap-mx.service
+++ b/debian/leap-mx.service
@@ -1,0 +1,1 @@
+../pkg/leap-mx.service

--- a/pkg/leap-mx.service
+++ b/pkg/leap-mx.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Leap MX
+Before=postfix.service
+
+[Service]
+ExecStart=/usr/bin/python /usr/bin/twistd -n --rundir=/var/lib/leap_mx/ --python=/usr/share/app/mx.tac --syslog --prefix=leap-mx --pidfile=/tmp/leap-mx.pid
+User=leap-mx
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
leap-mx can now be started and stopped by systemd.

This also fixes #7755.

Beware: this adds build-depends dh-systemd. dh-systemd is not available on wheezy